### PR TITLE
Added average speed and time in history section. 

### DIFF
--- a/index.js
+++ b/index.js
@@ -217,7 +217,7 @@ const showHistory = () => {
             historyBody.appendChild(row);
         });
         avgSpeed = (avgSpeed / historyArray.length).toFixed(1);
-        avgTime = (avgTime / historyArray.length).toFixed(3);;
+        avgTime = (avgTime / historyArray.length).toFixed(3);
         avgRow.innerHTML = `<td>${avgSpeed}</td><td>${avgTime}</td>`;
         avgHistoryBody.appendChild(avgRow);
     }

--- a/index.js
+++ b/index.js
@@ -190,6 +190,7 @@ const saveHistory = () => {
 
 // History Viewer
 const historyBody = document.getElementById("historyTableBody");
+const avgHistoryBody = document.getElementById("avgTableBody");
 
 const showHistory = () => {
     history = localStorage.getItem("typerHistory");
@@ -198,11 +199,24 @@ const showHistory = () => {
         document.getElementsByClassName("history")[0].style.display = "block";
         historyArray = JSON.parse(history);
         historyBody.innerHTML = "";
+        avgHistoryBody.innerHTML="";
+        const avgRow = document.createElement("tr");
+        let avgSpeed = 0;
+        let avgTime = 0;
         historyArray.forEach((item) => {
             const row = document.createElement("tr");
-            row.innerHTML = `<td>${htmlEncode(userName)}</td><td>${Math.ceil(item.extracted_words_length / (item.timeTaken / 60))}</td><td>${item.timeTaken}</td>`;
+            let speed = Math.ceil(item.extracted_words_length / (item.timeTaken / 60));
+            let time = item.timeTaken;
+            avgSpeed += speed;
+            avgTime += time;
+            row.innerHTML = `<td>${htmlEncode(userName)}</td><td>${speed}</td><td>${time}</td>`;
             historyBody.appendChild(row);
         });
+        avgSpeed = (avgSpeed / historyArray.length).toFixed(1);
+        avgTime = (avgTime / historyArray.length).toFixed(3);;
+        console.log(avgSpeed);
+        avgRow.innerHTML = `<td>${avgSpeed}</td><td>${avgTime}</td>`;
+        avgHistoryBody.appendChild(avgRow);
     }
     else {
         document.getElementsByClassName("history")[0].style.display = "none";

--- a/index.js
+++ b/index.js
@@ -218,7 +218,6 @@ const showHistory = () => {
         });
         avgSpeed = (avgSpeed / historyArray.length).toFixed(1);
         avgTime = (avgTime / historyArray.length).toFixed(3);;
-        console.log(avgSpeed);
         avgRow.innerHTML = `<td>${avgSpeed}</td><td>${avgTime}</td>`;
         avgHistoryBody.appendChild(avgRow);
     }

--- a/practice.css
+++ b/practice.css
@@ -214,6 +214,16 @@ h2.subtitle {
   margin: 0 auto;
 }
 
+.history-avg{
+  /* width: max-content; */
+  margin: 5px auto;
+  border-collapse: collapse;
+  overflow-x: auto;
+}
+.history-avg table{
+  margin: 0 auto;
+}
+
 .button-group{
   display: inline-block;
   margin: 25px 20px 25px;

--- a/practice.html
+++ b/practice.html
@@ -86,6 +86,18 @@
                     </tbody>
                 </table>
             </div>
+            <div class="history-avg">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Average Speed (wpm)</th>
+                            <th>Average Time Taken (sec)</th>
+                        </tr>
+                    </thead>
+                    <tbody id="avgTableBody">
+                    </tbody>
+                </table>
+            </div>
             <button id="historyResetBtn">Reset Data</button>
         </div>
     </div>

--- a/profile.html
+++ b/profile.html
@@ -50,6 +50,18 @@
                     </tbody>
                 </table>
             </div>
+            <div class="history-avg">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Average Speed (wpm)</th>
+                            <th>Average Time Taken (sec)</th>
+                        </tr>
+                    </thead>
+                    <tbody id="avgTableBody">
+                    </tbody>
+                </table>
+            </div>
             <button id="historyResetBtn">Reset Data</button>
         </div>
     </section>

--- a/profile.js
+++ b/profile.js
@@ -50,6 +50,7 @@ const saveHistory = () => {
 
 // History Viewer
 const historyBody = document.getElementById("historyTableBody");
+const avgHistoryBody = document.getElementById("avgTableBody");
 
 const showHistory = () => {
     history = localStorage.getItem("typerHistory");
@@ -58,12 +59,24 @@ const showHistory = () => {
         document.getElementsByClassName("history")[0].style.display = "block";
         historyArray = JSON.parse(history);
         historyBody.innerHTML = "";
+        avgHistoryBody.innerHTML="";
+        const avgRow = document.createElement("tr");
+        let avgSpeed = 0;
+        let avgTime = 0;
         historyArray.forEach((item) => {
             const row = document.createElement("tr");
-            row.innerHTML = `<td>${htmlEncode(userName)}</td><td>${Math.ceil(item.extracted_words_length / (item.timeTaken / 60))}</td><td>${item.timeTaken}</td>`;
+            let speed = Math.ceil(item.extracted_words_length / (item.timeTaken / 60));
+            let time = item.timeTaken;
+            avgSpeed += speed;
+            avgTime += time;
+            row.innerHTML = `<td>${htmlEncode(userName)}</td><td>${speed}</td><td>${time}</td>`;
             historyBody.appendChild(row);
         });
-        console.log("I am from show History");
+        avgSpeed = (avgSpeed / historyArray.length).toFixed(1);
+        avgTime = (avgTime / historyArray.length).toFixed(3);;
+        console.log(avgSpeed);
+        avgRow.innerHTML = `<td>${avgSpeed}</td><td>${avgTime}</td>`;
+        avgHistoryBody.appendChild(avgRow);
     }
     else {
         document.getElementsByClassName("history")[0].style.display = "none";

--- a/profile.js
+++ b/profile.js
@@ -74,7 +74,6 @@ const showHistory = () => {
         });
         avgSpeed = (avgSpeed / historyArray.length).toFixed(1);
         avgTime = (avgTime / historyArray.length).toFixed(3);;
-        console.log(avgSpeed);
         avgRow.innerHTML = `<td>${avgSpeed}</td><td>${avgTime}</td>`;
         avgHistoryBody.appendChild(avgRow);
     }

--- a/profile.js
+++ b/profile.js
@@ -73,7 +73,7 @@ const showHistory = () => {
             historyBody.appendChild(row);
         });
         avgSpeed = (avgSpeed / historyArray.length).toFixed(1);
-        avgTime = (avgTime / historyArray.length).toFixed(3);;
+        avgTime = (avgTime / historyArray.length).toFixed(3);
         avgRow.innerHTML = `<td>${avgSpeed}</td><td>${avgTime}</td>`;
         avgHistoryBody.appendChild(avgRow);
     }


### PR DESCRIPTION
This PR is intended to resolve #44.

I added avg time and speed to both history sections in the practice and profile pages.

## Code Changes
- Added new table below existing history table to display averages
- In `showHistory()` added new table row element creation for the avg table.
- Added new variables in `showHistory()` to calculate average times.
- Simplified `innerHTML` string for the existing table with new variables.
- Added additional CSS to match new table with the existing table.