### PR TITLE
Removing GitHub logo from Practice page (Fixes #68)

### DIFF
--- a/practice.html
+++ b/practice.html
@@ -24,8 +24,6 @@
                     <li class="nav-item"><a href="practice.html" class="nav-item-link">Practice</a></li>
                     <li class="nav-item"><a href="about.html" class="nav-item-link">About</a></li>
                     <li class="nav-item"><a href="profile.html" class="nav-item-link">Profile</a></li>
-                    <li class="nav-item"><a href="https://github.com/arpitghura/typing-test" class="nav-item-link"><i
-                                class="fa fa-github" style="font-size:24px"></i></a></li>
                 </ul>
             </div>
             <div class="github-icon">


### PR DESCRIPTION
GitHub logo has been removed under the practice page 
Fixes #68 
![image](https://user-images.githubusercontent.com/96040322/207317228-6175dc6f-31da-4986-8349-f28766b3b569.png)

KWOC