### PR TITLE
Fix: Remove unwanted space between GitHub icon and dark mode button

### DIFF
--- a/about.html
+++ b/about.html
@@ -24,10 +24,12 @@
                     <li class="nav-item"><a href="profile.html" class="nav-item-link">Profile</a></li>
                 </ul>
             </div>
-            <div class="github-icon">
-                <a href="https://github.com/arpitghura/typing-test" class="nav-item-link"><i class='bx bx-sm bxl-github'></i></a>
+            <div class="nav-right">
+                <div class="github-icon">
+                    <a href="https://github.com/arpitghura/typing-test" class="nav-item-link"><i class='bx bx-sm bxl-github'></i></a>
+                </div>
+                <button onclick="toggleLightDarkMode()" class="dark-btn">Dark Mode</button>     
             </div>
-            <button onclick="toggleLightDarkMode()" class="dark-btn">Dark Mode</button>
             <div class="mobile-nav">
                 <div class="bar1"></div>
                 <div class="bar2"></div>

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -47,6 +47,10 @@ main{
   z-index: 15;
   padding: 1rem 0.2rem;
 }
+.nav-right {
+  display: flex;
+  align-items: center;
+}
 .brand-name{
   margin-left: 10px;
   text-decoration: none;

--- a/practice.html
+++ b/practice.html
@@ -27,10 +27,12 @@
                     <li class="nav-item"><a href="profile.html" class="nav-item-link">Profile</a></li>
                 </ul>
             </div>
-            <div class="github-icon">
-                <a href="https://github.com/arpitghura/typing-test" class="nav-item-link"><i class='bx bx-sm bxl-github'></i></a>
+            <div class="nav-right">
+                <div class="github-icon">
+                    <a href="https://github.com/arpitghura/typing-test" class="nav-item-link"><i class='bx bx-sm bxl-github'></i></a>
+                </div>
+                <button onclick="toggleLightDarkMode()" class="dark-btn">Dark Mode</button>
             </div>
-            <button onclick="toggleLightDarkMode()" class="dark-btn">Dark Mode</button>
             <div class="mobile-nav">
                 <div class="bar1"></div>
                 <div class="bar2"></div>

--- a/profile.html
+++ b/profile.html
@@ -26,10 +26,12 @@
                     <li class="nav-item"><a href="profile.html" class="nav-item-link">Profile</a></li>
                 </ul>
             </div>
-            <div class="github-icon">
-                <a href="https://github.com/arpitghura/typing-test" class="nav-item-link"><i class='bx bx-sm bxl-github'></i></a>
+            <div class="nav-right">
+                <div class="github-icon">
+                    <a href="https://github.com/arpitghura/typing-test" class="nav-item-link"><i class='bx bx-sm bxl-github'></i></a>
+                </div>
+                <button onclick="toggleLightDarkMode()" class="dark-btn">Dark Mode</button>
             </div>
-            <button onclick="toggleLightDarkMode()" class="dark-btn">Dark Mode</button>
             <div class="mobile-nav">
                 <div class="bar1"></div>
                 <div class="bar2"></div>


### PR DESCRIPTION
**Describe the bug**
The GitHub Button and dark mode button has unwanted space in middle on all pages except index.html, remove it.

**Expected behavior**
Both the GitHub icon and dark mode button be adjacent.

**Solution**
Group the buttons under a parent flex component so they remain together.

**Screenshot**
![image](https://user-images.githubusercontent.com/122832270/212771961-4d638dc1-1244-4a6b-a6a2-e40819e514d3.png)